### PR TITLE
Logging 설정 추가

### DIFF
--- a/cogether/settings/prod.py
+++ b/cogether/settings/prod.py
@@ -33,3 +33,24 @@ DATABASES = {
     },
 }
 
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            # 'filename': '/home/user/app/5th-cogether-back/log/debug.log', log 파일 경로로 지정해줘
+            # 해당 경로에 django 로그가 쌓입니다. 에러나거나 할 때 들어가서 보면 용이
+            # Sentry도 붙이도록 할게용!
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
+    },
+}


### PR DESCRIPTION
주석처리한 부분 파일경로만 서버에 원하는 파일경로로 바꿔줘
보통 `home/user/log/cogether/debug.log` 정도로 지정하는둡!

그 후 에러가나거나 할 때 로그확인은 서버에 해당 로그 파일 들어가서 보면 됩니다.
보통 파일이 크게 많이 쌓인 경우에는 `tail` 명령어 사용해서 끝에서부터 보는 경우가 많아!
우리회사는 Sentry유용하게 사용하는데 free계정으로 만들면 우리한테 얼마나 유용할지 내가 검토해보고 붙일게